### PR TITLE
feat: add support for proxy protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.github.cytechmobile</groupId>
 	<artifactId>cloudhopper-smpp</artifactId>
 	<packaging>jar</packaging>
-	<version>7.0.14</version>
+	<version>7.1.0</version>
 	<name>cloudhopper-smpp</name>
 	<description>Efficient, scalable, and flexible Java implementation of the Short Messaging Peer to Peer Protocol (SMPP)</description>
 	<url>https://github.com/cytechmobile/cloudhopper-smpp</url>

--- a/src/main/java/com/cloudhopper/smpp/SmppServerConfiguration.java
+++ b/src/main/java/com/cloudhopper/smpp/SmppServerConfiguration.java
@@ -58,6 +58,7 @@ public class SmppServerConfiguration extends SmppConnectionConfiguration {
     private long defaultRequestExpiryTimeout = SmppConstants.DEFAULT_REQUEST_EXPIRY_TIMEOUT;
     private long defaultWindowMonitorInterval = SmppConstants.DEFAULT_WINDOW_MONITOR_INTERVAL;
     private boolean defaultSessionCountersEnabled = false;
+    private boolean proxyProtocol = false;
 
     public SmppServerConfiguration() {
         super("0.0.0.0", 2775, SmppConstants.DEFAULT_BIND_TIMEOUT);
@@ -153,12 +154,20 @@ public class SmppServerConfiguration extends SmppConnectionConfiguration {
     }
 
     public void setSslConfiguration(SslConfiguration value) {
-	this.sslConfiguration = value;
-	setUseSsl(true);
+        this.sslConfiguration = value;
+        setUseSsl(true);
     }
 
     public SslConfiguration getSslConfiguration() {
-	return this.sslConfiguration;
+        return this.sslConfiguration;
+    }
+
+    public boolean isProxyProtocol() {
+        return proxyProtocol;
+    }
+
+    public void setProxyProtocol(boolean proxyProtocol) {
+        this.proxyProtocol = proxyProtocol;
     }
 
     /**

--- a/src/main/java/com/cloudhopper/smpp/channel/SmppServerConnector.java
+++ b/src/main/java/com/cloudhopper/smpp/channel/SmppServerConnector.java
@@ -81,7 +81,9 @@ public class SmppServerConnector extends LoggingChannelInboundHandlerAdapter {
         // add SSL handler
         if (server.getConfiguration().isUseSsl()) {
             SslConfiguration sslConfig = server.getConfiguration().getSslConfiguration();
-        if (sslConfig == null) throw new IllegalStateException("sslConfiguration must be set");
+            if (sslConfig == null) {
+                throw new IllegalStateException("sslConfiguration must be set");
+            }
             SslContextFactory factory = new SslContextFactory(sslConfig);
             SSLEngine sslEngine = factory.newSslEngine();
             sslEngine.setUseClientMode(false);

--- a/src/main/java/com/cloudhopper/smpp/impl/UnboundSmppSession.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/UnboundSmppSession.java
@@ -24,7 +24,15 @@ import com.cloudhopper.smpp.SmppBindType;
 import com.cloudhopper.smpp.SmppConstants;
 import com.cloudhopper.smpp.SmppSessionConfiguration;
 import com.cloudhopper.smpp.channel.ChannelUtil;
-import com.cloudhopper.smpp.pdu.*;
+import com.cloudhopper.smpp.pdu.BaseBind;
+import com.cloudhopper.smpp.pdu.BaseBindResp;
+import com.cloudhopper.smpp.pdu.BindReceiver;
+import com.cloudhopper.smpp.pdu.BindTransceiver;
+import com.cloudhopper.smpp.pdu.BindTransmitter;
+import com.cloudhopper.smpp.pdu.EnquireLink;
+import com.cloudhopper.smpp.pdu.EnquireLinkResp;
+import com.cloudhopper.smpp.pdu.Pdu;
+import com.cloudhopper.smpp.pdu.PduResponse;
 import com.cloudhopper.smpp.type.LoggingOptions;
 import com.cloudhopper.smpp.type.SmppChannelException;
 import com.cloudhopper.smpp.type.SmppProcessingException;
@@ -160,6 +168,10 @@ public class UnboundSmppSession implements SmppSessionChannelListener {
         sessionConfiguration.setAddressRange(bindRequest.getAddressRange());
         sessionConfiguration.setHost(ChannelUtil.getChannelRemoteHost(channel));
         sessionConfiguration.setPort(ChannelUtil.getChannelRemotePort(channel));
+        if (ChannelUtil.isProxied(channel)) {
+            sessionConfiguration.setProxyHost(ChannelUtil.getProxiedChannelProxyHost(channel));
+            sessionConfiguration.setProxyPort(ChannelUtil.getProxiedChannelProxyPort(channel));
+        }
         sessionConfiguration.setInterfaceVersion(bindRequest.getInterfaceVersion());
 
         LoggingOptions loggingOptions = new LoggingOptions();

--- a/src/main/java/com/cloudhopper/smpp/type/SmppConnectionConfiguration.java
+++ b/src/main/java/com/cloudhopper/smpp/type/SmppConnectionConfiguration.java
@@ -35,6 +35,9 @@ public class SmppConnectionConfiguration {
     private String clientBindHost;
     private int clientBindPort;
 
+    private String proxyHost;
+    private int proxyPort;
+
     public SmppConnectionConfiguration() {
         this(null, 0, SmppConstants.DEFAULT_CONNECT_TIMEOUT);
     }
@@ -90,5 +93,21 @@ public class SmppConnectionConfiguration {
 
     public void setClientBindPort(int clientBindPort) {
         this.clientBindPort = clientBindPort;
+    }
+
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    public int getProxyPort() {
+        return proxyPort;
+    }
+
+    public void setProxyPort(int proxyPort) {
+        this.proxyPort = proxyPort;
     }
 }


### PR DESCRIPTION
Add support for proxy protocol. If server configuration enables proxy protocol support, add netty's proxy protocol handler first (HAProxyMessageDecoder) and on proxy message add original client ip/port to channel as attrs, which are read from ChannelUtil to correctly "mask" the remote address.